### PR TITLE
Update thumbnail statement to work with changes to CurseAPI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'application'
 }
-version = '1.2.0'
+version = '1.2.1'
 group = "de.erdbeerbaerlp.curseforgeBot" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 mainClassName = 'de.erdbeerbaerlp.curseforgeBot.Main'
 repositories {

--- a/src/main/java/de/erdbeerbaerlp/curseforgeBot/EmbedMessage.java
+++ b/src/main/java/de/erdbeerbaerlp/curseforgeBot/EmbedMessage.java
@@ -15,7 +15,7 @@ public class EmbedMessage {
     public static void messageWithoutLink(CurseProject proj, CurseFile file, TextChannel channel) throws CurseException {
 	EmbedBuilder embed = new EmbedBuilder();
 	embed.setTitle(proj.name(), proj.url().toString());
-	embed.setThumbnail(proj.avatarThumbnailURL().toString());
+	embed.setThumbnail(projproj.logo().thumbnailURL().toString());
 	embed.setDescription(getMessageDescription());
 	embed.addField(EmbedBuilder.ZERO_WIDTH_SPACE,
 		"**Release Type**: `" + file.releaseType().name() + "`" +
@@ -29,7 +29,7 @@ public class EmbedMessage {
     public static void messageWithCurseLink(CurseProject proj, CurseFile file, TextChannel channel) throws CurseException {
 	EmbedBuilder embed = new EmbedBuilder();
 	embed.setTitle(proj.name(), proj.url().toString());
-	embed.setThumbnail(proj.avatarThumbnailURL().toString());
+	embed.setThumbnail(projproj.logo().thumbnailURL().toString());
 	embed.setDescription(getMessageDescription());
 	embed.addField(EmbedBuilder.ZERO_WIDTH_SPACE,
 		"**Release Type**: `" + file.releaseType().name() + "`" +
@@ -44,7 +44,7 @@ public class EmbedMessage {
     public static void messageWithDirectLink(CurseProject proj, CurseFile file, TextChannel channel) throws CurseException {
 	EmbedBuilder embed = new EmbedBuilder();
 	embed.setTitle(proj.name(), proj.url().toString());
-	embed.setThumbnail(proj.avatarThumbnailURL().toString());
+	embed.setThumbnail(projproj.logo().thumbnailURL().toString());
 	embed.setDescription(getMessageDescription());
 	embed.addField(EmbedBuilder.ZERO_WIDTH_SPACE,
 		"**Release Type**: `" + file.releaseType().name() + "`" +

--- a/src/main/java/de/erdbeerbaerlp/curseforgeBot/EmbedMessage.java
+++ b/src/main/java/de/erdbeerbaerlp/curseforgeBot/EmbedMessage.java
@@ -15,7 +15,7 @@ public class EmbedMessage {
     public static void messageWithoutLink(CurseProject proj, CurseFile file, TextChannel channel) throws CurseException {
 	EmbedBuilder embed = new EmbedBuilder();
 	embed.setTitle(proj.name(), proj.url().toString());
-	embed.setThumbnail(projproj.logo().thumbnailURL().toString());
+	embed.setThumbnail(proj.logo().thumbnailURL().toString());
 	embed.setDescription(getMessageDescription());
 	embed.addField(EmbedBuilder.ZERO_WIDTH_SPACE,
 		"**Release Type**: `" + file.releaseType().name() + "`" +
@@ -29,7 +29,7 @@ public class EmbedMessage {
     public static void messageWithCurseLink(CurseProject proj, CurseFile file, TextChannel channel) throws CurseException {
 	EmbedBuilder embed = new EmbedBuilder();
 	embed.setTitle(proj.name(), proj.url().toString());
-	embed.setThumbnail(projproj.logo().thumbnailURL().toString());
+	embed.setThumbnail(proj.logo().thumbnailURL().toString());
 	embed.setDescription(getMessageDescription());
 	embed.addField(EmbedBuilder.ZERO_WIDTH_SPACE,
 		"**Release Type**: `" + file.releaseType().name() + "`" +
@@ -44,7 +44,7 @@ public class EmbedMessage {
     public static void messageWithDirectLink(CurseProject proj, CurseFile file, TextChannel channel) throws CurseException {
 	EmbedBuilder embed = new EmbedBuilder();
 	embed.setTitle(proj.name(), proj.url().toString());
-	embed.setThumbnail(projproj.logo().thumbnailURL().toString());
+	embed.setThumbnail(proj.logo().thumbnailURL().toString());
 	embed.setDescription(getMessageDescription());
 	embed.addField(EmbedBuilder.ZERO_WIDTH_SPACE,
 		"**Release Type**: `" + file.releaseType().name() + "`" +


### PR DESCRIPTION
No longer works
`proj.avatarThumbnailURL().toString()`

thumbnailURL() moved to logo()
`proj.logo().thumbnailURL().toString()`